### PR TITLE
Nwm login register

### DIFF
--- a/whodunit/urls.py
+++ b/whodunit/urls.py
@@ -15,7 +15,16 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.conf.urls import include
+from django.urls import path
+from whodunitapi.views import register_user, login_user
+
+
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('register', register_user),
+    path('login', login_user),
+    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/whodunit/urls.py
+++ b/whodunit/urls.py
@@ -24,7 +24,12 @@ from whodunitapi.views import register_user, login_user
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+
+    # Requests to http://localhost:8000/register will be routed to the register_user function
     path('register', register_user),
+    
+    # Requests to http://localhost:8000/login will be routed to the login_user function
     path('login', login_user),
+
     path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/whodunitapi/views/__init__.py
+++ b/whodunitapi/views/__init__.py
@@ -1,0 +1,1 @@
+from .auth import login_user, register_user

--- a/whodunitapi/views/auth.py
+++ b/whodunitapi/views/auth.py
@@ -1,0 +1,77 @@
+import json
+from whodunitapi.models.player import Player
+from django.http import HttpResponse
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from django.views.decorators.csrf import csrf_exempt
+from whodunitapi.models import Player
+
+
+@csrf_exempt
+def login_user(request):
+    '''Handles the authentication of a player
+    Method arguments:
+      request -- The full HTTP request object
+    '''
+
+    req_body = json.loads(request.body.decode())
+
+    # If the request is a HTTP POST, try to pull out the relevant information.
+    if request.method == 'POST':
+
+        # Use the built-in authenticate method to verify
+        username = req_body['username']
+        password = req_body['password']
+        authenticated_user = authenticate(username=username, password=password)
+
+        # If authentication was successful, respond with their token
+        if authenticated_user is not None:
+            token = Token.objects.get(user=authenticated_user)
+            data = json.dumps({"valid": True, "token": token.key})
+
+            return HttpResponse(data, content_type='application/json')
+
+        else:
+            # Bad login details were provided. So we can't log the user in.
+            data = json.dumps({"valid": False})
+
+            return HttpResponse(data, content_type='application/json')
+
+
+@csrf_exempt
+def register_user(request):
+    '''Handles the creation of a new player for authentication
+    Method arguments:
+      request -- The full HTTP request object
+    '''
+
+    # Load the JSON string of the request body into a dict
+    req_body = json.loads(request.body.decode())
+
+    # Create a new user by invoking the `create_user` helper method
+    # on Django's built-in User model
+    new_user = User.objects.create_user(
+        username=req_body['username'],
+        email=req_body['email'],
+        password=req_body['password'],
+        first_name=req_body['first_name'],
+        last_name=req_body['last_name'],
+        profile_image_url=req_body['profile_image_url']
+    )
+
+    # Now save the extra info in the whodunitapi_player table
+    player = Player.objects.create(
+        bio=req_body['bio'],
+        user=new_user
+    )
+
+    # Commit the user to the database by saving it
+    player.save()
+
+    # Use the REST Framework's token generator on the new user account
+    token = Token.objects.create(user=new_user)
+
+    # Return the token to the client
+    data = json.dumps({"token": token.key})
+    return HttpResponse(data, content_type='application/json')


### PR DESCRIPTION
Description of PR that completes issue here...
the issue is that for this app a user will need to first register as a user and then be assigned a token. once they are registered, that user can then log into the application. 
Added login and registration routes, and methods,  to enable authentication. Authentication for logging in to be added when a user registers so that an authentication token identifies a user, and not their primary key

## Changes

- Item 1 ADDED  authentication token in an HTTP response
- Item 2 added whodunitapi/views/auth.py
- Item 3 updated whodunitapi/views/__init__.py and whodunit/urls.py

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/products` Creates a new product

when the user request to POST while logging in, the built in Django  authentication will use a authenticate method to verify the user with the user name an passwords

